### PR TITLE
feat: Add bring-your-own-ip adresses capability

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.83.6
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.35 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ No modules.
 | <a name="input_flow_logs_s3_bucket"></a> [flow\_logs\_s3\_bucket](#input\_flow\_logs\_s3\_bucket) | The name of the Amazon S3 bucket for the flow logs. Required if `flow_logs_enabled` is `true` | `string` | `null` | no |
 | <a name="input_flow_logs_s3_prefix"></a> [flow\_logs\_s3\_prefix](#input\_flow\_logs\_s3\_prefix) | The prefix for the location in the Amazon S3 bucket for the flow logs. Required if `flow_logs_enabled` is `true` | `string` | `null` | no |
 | <a name="input_ip_address_type"></a> [ip\_address\_type](#input\_ip\_address\_type) | The value for the address type. Defaults to `IPV4`. Valid values: `IPV4` | `string` | `"IPV4"` | no |
-| <a name="input_ip_addresses"></a> [ip\_addresses](#input\_ip\_addresses) | The IP addresses to use for BYOIP accelerators. If not specified, the service assigns IP addresses. Valid values: 1 or 2 IPv4 addresses. | `list(string)` | `[]` | no |
+| <a name="input_ip_addresses"></a> [ip\_addresses](#input\_ip\_addresses) | The IP addresses to use for BYOIP accelerators. If not specified, the service assigns IP addresses. Valid values: 1 or 2 IPv4 addresses | `list(string)` | `[]` | no |
 | <a name="input_listeners"></a> [listeners](#input\_listeners) | A map of listener defintions to create | `any` | `{}` | no |
 | <a name="input_listeners_timeouts"></a> [listeners\_timeouts](#input\_listeners\_timeouts) | Create, update, and delete timeout configurations for the listeners | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the accelerator | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ No modules.
 | <a name="input_flow_logs_s3_bucket"></a> [flow\_logs\_s3\_bucket](#input\_flow\_logs\_s3\_bucket) | The name of the Amazon S3 bucket for the flow logs. Required if `flow_logs_enabled` is `true` | `string` | `null` | no |
 | <a name="input_flow_logs_s3_prefix"></a> [flow\_logs\_s3\_prefix](#input\_flow\_logs\_s3\_prefix) | The prefix for the location in the Amazon S3 bucket for the flow logs. Required if `flow_logs_enabled` is `true` | `string` | `null` | no |
 | <a name="input_ip_address_type"></a> [ip\_address\_type](#input\_ip\_address\_type) | The value for the address type. Defaults to `IPV4`. Valid values: `IPV4` | `string` | `"IPV4"` | no |
+| <a name="input_ip_addresses"></a> [ip\_addresses](#input\_ip\_addresses) | The IP addresses to use for BYOIP accelerators. If not specified, the service assigns IP addresses. Valid values: 1 or 2 IPv4 addresses. | `list(string)` | `[]` | no |
 | <a name="input_listeners"></a> [listeners](#input\_listeners) | A map of listener defintions to create | `any` | `{}` | no |
 | <a name="input_listeners_timeouts"></a> [listeners\_timeouts](#input\_listeners\_timeouts) | Create, update, and delete timeout configurations for the listeners | `map(string)` | `{}` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the accelerator | `string` | `""` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,13 +24,13 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.35 |
 
 ## Modules
 
@@ -40,7 +40,7 @@ Note that this example may create resources which will incur monetary charges on
 | <a name="module_global_accelerator"></a> [global\_accelerator](#module\_global\_accelerator) | ../.. | n/a |
 | <a name="module_global_accelerator_disabled"></a> [global\_accelerator\_disabled](#module\_global\_accelerator\_disabled) | ../.. | n/a |
 | <a name="module_s3_log_bucket"></a> [s3\_log\_bucket](#module\_s3\_log\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -97,8 +97,6 @@ module "global_accelerator" {
 
   name = local.name
 
-  ip_addresses = ["0.0.0.0", "1.1.1.1"]
-
   flow_logs_enabled   = true
   flow_logs_s3_bucket = module.s3_log_bucket.s3_bucket_id
   flow_logs_s3_prefix = local.name

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -21,7 +21,7 @@ data "aws_caller_identity" "current" {}
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 3.0"
+  version = "~> 5.0"
 
   name = local.name
   cidr = "10.99.0.0/18"
@@ -96,6 +96,8 @@ module "global_accelerator" {
   source = "../.."
 
   name = local.name
+
+  ip_addresses = ["0.0.0.0", "1.1.1.1"]
 
   flow_logs_enabled   = true
   flow_logs_s3_bucket = module.s3_log_bucket.s3_bucket_id

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 4.35"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ resource "aws_globalaccelerator_accelerator" "this" {
 
   name            = var.name
   ip_address_type = var.ip_address_type
+  ip_addresses    = var.ip_addresses
   enabled         = var.enabled
 
   dynamic "attributes" {
@@ -48,7 +49,7 @@ resource "aws_globalaccelerator_listener" "this" {
 }
 
 ################################################################################
-# Endpoing Group(s)
+# Endpoint Group(s)
 ################################################################################
 
 resource "aws_globalaccelerator_endpoint_group" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -27,14 +27,9 @@ variable "ip_address_type" {
 }
 
 variable "ip_addresses" {
-  description = "The IP addresses to use for BYOIP accelerators. If not specified, the service assigns IP addresses. Valid values: 1 or 2 IPv4 addresses."
+  description = "The IP addresses to use for BYOIP accelerators. If not specified, the service assigns IP addresses. Valid values: 1 or 2 IPv4 addresses"
   type        = list(string)
   default     = []
-
-  validation {
-    condition     = length(var.ip_addresses) <= 2
-    error_message = "Limit 2 IPv4 addresses."
-  }
 }
 
 variable "enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,17 @@ variable "ip_address_type" {
   default     = "IPV4"
 }
 
+variable "ip_addresses" {
+  description = "The IP addresses to use for BYOIP accelerators. If not specified, the service assigns IP addresses. Valid values: 1 or 2 IPv4 addresses."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.ip_addresses) <= 2
+    error_message = "Limit 2 IPv4 addresses."
+  }
+}
+
 variable "enabled" {
   description = "Indicates whether the accelerator is enabled. Defaults to `true`. Valid values: `true`, `false`"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 4.35"
     }
   }
 }


### PR DESCRIPTION
## Description

This PR adds the ability to configure the Global Accelerator with IPv4 addresses via `var.ip_addresses`, rather than using the default randomly allocated addresses. This can be used with BYOIP (bring your own IP), or AWS Elastic IPs. This does not add Elastic IPs to the module.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/globalaccelerator_accelerator#ip_addresses


## Motivation and Context

I want to be able to use pre-defined EIPs in my Global Accelerator, and the resource input is not currently exposed via this module.

## Breaking Changes

Updated minimum AWS provider version to `4.35`, which adds the `ip_addresses` input. https://github.com/hashicorp/terraform-provider-aws/pull/27181

No other breaking changes, default value for the new variable is empty. Module will continue to assign IPs unless explicitly provided by inputs.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
