### PR TITLE
fix: Create an endpoint group only when a definition is provided under the `endpoint_group` argument

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ resource "aws_globalaccelerator_listener" "this" {
 ################################################################################
 
 resource "aws_globalaccelerator_endpoint_group" "this" {
-  for_each = { for k, v in var.listeners : k => v if var.create && var.create_listeners && length(lookup(var.listeners[k], "endpoint_group", {})) >= 0 }
+  for_each = { for k, v in var.listeners : k => v if var.create && var.create_listeners && length(lookup(var.listeners[k], "endpoint_group", {})) > 0 }
 
   listener_arn = aws_globalaccelerator_listener.this[each.key].id
 


### PR DESCRIPTION
Create an endpoint group only, when the listener's endpoint group is not empty

## Description

- Create an endpoint group only, when the listener's endpoint group is not empty

## Motivation and Context

- Endpoint group should not be created when it was not defined in the inputs
- Resolves #13

## Breaking Changes

- No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I have tested and validated these changes using the same setup I mentioned in the issue. I created an accelerator resource, and then I created a listener resource
